### PR TITLE
catch BadRequestsError and extract the reason

### DIFF
--- a/flask_mail_sendgrid.py
+++ b/flask_mail_sendgrid.py
@@ -16,6 +16,7 @@ from sendgrid.helpers.mail import Content
 from sendgrid.helpers.mail import Personalization
 from sendgrid.helpers.mail import Attachment
 from flask_mail import Message
+from python_http_client.exceptions import BadRequestsError
 
 class MailSendGrid():
     def __init__(self, app=None):
@@ -88,9 +89,12 @@ class MailSendGrid():
 
     def send(self, message):
         mail = self._make_sendgrid_mail(message)
-        res = self.sg.client.mail.send.post(request_body=mail.get())
-        if int(res.status_code / 100) != 2:
-            raise Exception("error response from sendgrid {}".format(res.status_code))
+        try:
+            res = self.sg.client.mail.send.post(request_body=mail.get())
+            if int(res.status_code / 100) != 2:
+                raise Exception("error response from sendgrid {}".format(res.status_code))
+        except BadRequestsError as e:
+            raise Exception("sendgrid response {}: {}".format(e.status_code, e.body))
 
     def __getattr__(self, name):
         return getattr(self.state, name, None)


### PR DESCRIPTION
so the user can see in the flask logs *why* an email request is failing

eg:
```Exception: sendgrid response 400: b'{"errors":[{"message":"Invalid from email address","field":"from","help":null}]}'```